### PR TITLE
Fix ImageView id in fragment_game_over.xml

### DIFF
--- a/app/src/main/res/layout/fragment_game_over.xml
+++ b/app/src/main/res/layout/fragment_game_over.xml
@@ -26,7 +26,7 @@
         android:background="@color/gameOverBackground">
 
         <ImageView
-            android:id="@+id/gameOverFragment"
+            android:id="@+id/youLoseImage"
             android:layout_width="wrap_content"
             android:layout_height="362dp"
             android:layout_marginStart="@dimen/horizontal_margin"


### PR DESCRIPTION
The current id, "gameOverFragment," describes a Fragment, when it should be describing an ImageView.
The proposed change, "youLoseImage," would match the id of the ImageView in the sister fragment, "youWinImage."
The current id is meant to be used later in the navigation graph, which will result in a conflict or Android Studio automatically choosing the name "gameOverFragment2," which could be confusing since it doesn't match video on Udacity.