### PR TITLE
solve warning when call resolveActivity fun

### DIFF
--- a/app/src/main/java/com/example/android/navigation/GameWonFragment.kt
+++ b/app/src/main/java/com/example/android/navigation/GameWonFragment.kt
@@ -66,7 +66,7 @@ class GameWonFragment : Fragment() {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.winner_menu, menu)
         // check if the activity resolves
-        if (null == getShareIntent().resolveActivity(requireActivity().packageManager)) {
+        if (null == requireActivity().packageManager.resolveActivity(getShareIntent(),0)) {
             // hide the menu item if it doesn't resolve
             menu.findItem(R.id.share)?.isVisible = false
         }


### PR DESCRIPTION
Consider adding a `<queries>` declaration to your manifest when calling this method; see https://g.co/dev/packagevisibility for details